### PR TITLE
Update make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,6 @@ makedocs(
 
 deploydocs(
     repo = "github.com/ACCORD-NWP/DAVAI.git",
-    devbranch = "main",
-    devurl = "main",
+    devbranch = "develop",
+    devurl = "dev",
 )


### PR DESCRIPTION
This should fix: 

 Info: Deployment criteria for deploying devbranch build from GitHub Actions:
│ - ✔ ENV["GITHUB_REPOSITORY"]="ACCORD-NWP/DAVAI" occurs in repo="github.com/ACCORD-NWP/DAVAI.git"
│ - ✔ ENV["GITHUB_EVENT_NAME"]="push" is "push", "workflow_dispatch" or "schedule"
│ - ✘ ENV["GITHUB_REF"] matches devbranch="main"
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["GITHUB_TOKEN"] exists and is non-empty
└ Deploying: ✘
