### PR TITLE
Add 3DEnVar+SDL analysis in NRV and ELP usecases (based on DV50T1)

### DIFF
--- a/src/tasks/assim/arome_BA3DEnVar_OOPS.py
+++ b/src/tasks/assim/arome_BA3DEnVar_OOPS.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Driver, Family, LoopFamily
+
+from .raw2odb.batodbNew import BatorODB
+from .minims.OOPSAnalysis_LAM3DEnVar import OOPSAnalysisLAM3DEnVar as Analysis
+
+
+def setup(t, **kw):
+    return Driver(tag='drv', ticket=t, options=kw, nodes=[
+        Family(tag='arome', ticket=t, nodes=[
+            Family(tag='3dvar3h', ticket=t, nodes=[
+                Family(tag='default_compilation_flavour', ticket=t, nodes=[
+                    LoopFamily(tag='rundates', ticket=t,
+                        loopconf='rundates',
+                        loopsuffix='.{}',
+                        nodes=[
+                            Family(tag='BA', ticket=t, on_error='delayed_fail', nodes=[
+                                BatorODB(tag='batodb', ticket=t, **kw),
+                                Analysis(tag='analysis', ticket=t, **kw),
+                            ], **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
+            ], **kw),
+        ],
+    )
+

--- a/src/tasks/assim/minims/OOPSAnalysis_LAM3DEnVar.py
+++ b/src/tasks/assim/minims/OOPSAnalysis_LAM3DEnVar.py
@@ -1,0 +1,443 @@
+# -*- coding: utf-8 -*-
+
+from footprints import FPDict
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Task
+import davai
+
+from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
+from davai.vtx.hooks.namelists import hook_adjust_DFI, hook_gnam
+
+
+class OOPSAnalysisLAM3DEnVar(Task, DavaiIALTaskMixin, IncludesTaskMixin):
+
+    experts = [FPDict({'kind':'joTables'})] + davai.vtx.util.default_experts()
+    _flow_input_task_tag = 'batodb'
+
+    def process(self):
+        self._wrapped_init()
+        self._obstype_rundate_association()
+        self._notify_start_inputs()
+
+        # 0./ Promises
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_promise(**self._promised_listing())
+            self._wrapped_promise(**self._promised_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 1.1.0/ Reference resources, to be compared to:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(**self._reference_continuity_expertise())
+            self._wrapped_input(**self._reference_continuity_listing())
+            #-------------------------------------------------------------------------------
+
+        # 1.1.1/ Static Resources:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._load_usual_tools()  # LFI tools, ecCodes defs, ...
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'GetIREmisAtlasInHDF',
+                format         = 'ascii',
+                genv           = self.conf.commonenv,
+                source         = 'uwir',
+                kind           = 'atlas_emissivity',
+                local          = 'uw_ir_emis_atlas_hdf5.tar',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'TelsemEmisAtlas',
+                format         = 'unknown',
+                source         = 'telsem',
+                genv           = self.conf.commonenv,
+                kind           = 'atlas_emissivity',
+                local          = 'telsem2_mw_atlas.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'MwaveRtCoef',
+                format         = 'unknown',
+                genv           = self.conf.appenv,
+                kind           = 'mwave_rtcoef',
+                local          = 'mwave_resources.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'AtlasEmissivity',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                instrument     = '[targetname]',
+                kind           = 'atlas_emissivity',
+                local          = 'ATLAS_[targetname:upper].BIN',
+                month          = self.conf.rundate,
+                targetname     = 'ssmis,iasi,an1,an2',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'AtlasEmissivitySeviri',
+                format         = 'unknown',
+                genv           = self.conf.appenv,
+                instrument     = '[targetname]',
+                kind           = 'atlas_emissivity',
+                local          = 'ATLAS_[targetname:upper].BIN',
+                month          = self.conf.rundate,
+                targetname     = 'seviri',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'AmvError',
+                format         = 'ascii',
+                genv           = self.conf.commonenv,
+                kind           = 'amv_error',
+                local          = 'amv_p_and_tracking_error',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'AmvBias',
+                format         = 'ascii',
+                genv           = self.conf.commonenv,
+                kind           = 'amv_bias',
+                local          = 'amv_bias_info',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RrtmConst',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rrtm',
+                local          = 'rrtm.const.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RsBiasTables',
+                format         = 'odb',
+                genv           = self.conf.commonenv,
+                kind           = 'odbraw',
+                layout         = 'RSTBIAS,COUNTRYRSTRHBIAS,SONDETYPERSTRHBIAS',
+                local          = '[layout:upper]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Coefmodel',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'coefmodel',
+                local          = 'COEF_MODEL.BIN',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'ScatCmod5',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'cmod5',
+                local          = 'fort.36',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RtCoef',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rtcoef',
+                local          = 'var.sat.misc_rtcoef.01.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Stabal',
+                format         = 'unknown',
+                genv           = self.conf.appenv,
+                kind           = 'stabal',
+                level          = '41',
+                local          = 'stabal96.[stat]',
+                stat           = 'bal,cv',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'IoassignScripts',
+                format         = 'ascii',
+                genv           = self.conf.commonenv,
+                kind           = 'ioassign_script',
+                language       = 'ksh',
+                local          = '[purpose]_ioassign',
+                purpose        = 'create,merge',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.2/ Static Resources (namelist(s) & config):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(
+                role           = 'Config',
+                format         = 'json',
+                genv           = self.conf.appenv,
+                intent         = 'inout',
+                kind           = 'config',
+                local          = 'oops.[format]',
+                nativefmt      = '[format]',
+                objects        = 'analyse-3DEnVarSDL_aro',
+                scope          = 'oops',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'ChannelsNamelist',
+                binary         = 'arpege',
+                channel        = 'cris331,iasi314',
+                format         = 'ascii',
+                genv           = self.conf.appenv,
+                kind           = 'namelist',
+                local          = 'namchannels_[channel]',
+                source         = 'namelist[channel]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'OOPSObjectsNamelists',
+                binary         = self.conf.model,
+                format         = 'ascii',
+                intent         = 'inout',
+                genv           = self.conf.appenv,
+                kind           = 'namelist',
+                local          = 'naml_[object]',
+                object         = ['standard_geometry','bmatrix_aro'],
+                source         = 'objects/naml_[object]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'OOPSObsObjectsNamelists',
+                binary         = self.conf.model,
+                format         = 'ascii',
+                intent         = 'inout',
+                genv           = self.conf.appenv,
+                kind           = 'namelist',
+                local          = 'naml_[object]',
+                object         = ['observations_aro'],
+                source         = 'objects/naml_[object]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'OOPSGomNamelists',
+                binary         = self.conf.model,
+                format         = 'ascii',
+                genv           = self.conf.appenv,
+                kind           = 'namelist',
+                local          = 'namelist_[object]',
+                object         = ['gom_setup_0', 'gom_setup_hres'], #, 'gom_setup'
+                source         = 'objects/naml_[object]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'OOPSModelObjectsNamelists',
+                binary         = self.conf.model,
+                format         = 'ascii',
+                genv           = self.conf.appenv,
+                intent         = 'inout',
+                kind           = 'namelist',
+                local          = 'naml_[object]',
+                hook_tstep     = (hook_gnam, {'NAMRIP':{'TSTEP':7200.}}),
+                object         = ['nonlinear_model_3dv_aro', 'linear_model_aro', 'traj_model_3dv_aro'],
+                source         = 'objects/naml_[object]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'OOPSWriteObjectsNamelists',
+                binary         = 'arome',
+                format         = 'ascii',
+                intent         = 'inout',
+                genv           = self.conf.appenv,
+                kind           = 'namelist',
+                local          = 'naml_[object]',
+                hook_write     = (hook_gnam, {'NAMOOPSWRITE':{'CDMEXP':'MXMINI'}}),
+                object         = ['write_analysis_aro'],
+                source         = 'objects/naml_[object]',
+            )
+            #-------------------------------------------------------------------------------
+            tbnam_leftovers = self._wrapped_input(
+                role           = 'NamelistLeftovers',
+                binary         = self.conf.model,
+                format         = 'ascii',
+                genv           = self.conf.appenv,
+                intent         = 'inout',
+                kind           = 'namelist',
+                local          = 'fort.4',
+                source         = 'objects/naml_leftovers_aro',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.3/ Static Resources (executables):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            tbio = self.flow_executable(
+                kind           = 'odbioassign',
+                local          = 'ioassign.x',
+            )
+            #-------------------------------------------------------------------------------
+            tbx = self.flow_executable(
+                kind           = 'oopsbinary',
+                run            = 'oovar',
+                local          = 'OOVAR.X',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.2/ Initial Flow Resources: theoretically flow-resources, but statically stored in input_shelf
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(
+                role           = 'BackgroundStdError',
+                block          = 'sigmab',
+                date           = '{}/-{}'.format(self.conf.rundate, 'PT6H'),  # FIXME: should be sthg like: self.conf.cyclestep),
+                experiment     = self.conf.input_shelf,
+                format         = 'grib',
+                geometry       = 'globalupd224',
+                kind           = 'bgstderr',
+                local          = 'errgrib.[variable]',          # FIXME : workaround in cy49T2
+                variable       = 'u,v,t,q,r,lnsp,gh,btmp,vo',   # to avoid using epygram (no grib support in cy49)
+                #local          = 'errgrib.',
+                #hook_split     = ('common.util.usepygram.split_errgrib_on_shortname'),
+                model          = 'arpege',
+                stage          = 'scr',
+                term           = 'PT6H',  # FIXME: should be sthg like: self.conf.cyclestep,
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Guess',
+                block          = 'cplguess',
+                date           = '{}/-{}'.format(self.conf.rundate, self.conf.cyclestep),
+                experiment     = self.conf.input_shelf,
+                format         = 'fa',
+                kind           = 'historic',
+                local          = 'ICMSHOOPSINIT',
+                term           = self.guess_term(),
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'VarBC',
+                block          = 'observations',
+                experiment     = self.conf.input_shelf,
+                format         = 'ascii',
+                intent         = 'inout',
+                kind           = 'varbc',
+                local          = 'VARBC.cycle',
+                stage          = 'merge',
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'ModelState',
+                block          = 'build_ensemble',
+                experiment     = self.conf.input_shelf,
+                #experiment     = 'shelf_cy50.02@vogtv', #for test purpose
+                format         = 'fa',
+                kind           = 'historic',
+                local          = 'ICMSHM[member]_term[term:fmth]',
+                member         = [1,2,3,4,5,6,7,8],
+                term           = '-3',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 2.1/ Flow Resources: produced by another task of the same job
+        if 'fetch' in self.steps:
+            tbmap = self._wrapped_input(
+                role           = 'Obsmap',
+                block          = self.input_block(),
+                experiment     = self.conf.xpid,
+                format         = 'ascii',
+                kind           = 'obsmap',
+                local          = 'bator_map',
+                stage          = 'build',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Observations',
+                block          = self.input_block(),
+                experiment     = self.conf.xpid,
+                format         = 'odb',
+                intent         = 'inout',
+                helper         = tbmap[0].contents,
+                kind           = 'observations',
+                local          = 'ECMA.[part]',
+                part           = tbmap[0].contents.odbset(),
+                stage          = 'build',
+            )
+            #-------------------------------------------------------------------------------
+        self._notify_inputs_done()
+        # 2.2/ Compute step
+        if 'compute' in self.steps:
+            self._notify_start_compute()
+            self.sh.title('Toolbox algo = tbalgo')
+            tbalgo = toolbox.algo(
+                crash_witness  = True,
+                drhookprof     = self.conf.drhook_profiling,
+                engine         = 'parallel',
+                iomethod       = '4',
+                kind           = 'ooanalysis',
+                npool          = self.conf.obs_npools,
+                slots          = self.obs_tslots,
+                withscreening  = True,                
+            )
+            print(self.ticket.prompt, 'tbalgo =', tbalgo)
+            print()
+            self.component_runner(tbalgo, tbx)
+            #-------------------------------------------------------------------------------
+            self.run_expertise()
+            #-------------------------------------------------------------------------------
+
+        # 2.3/ Flow Resources: produced by this task and possibly used by a subsequent flow-dependant task
+        if 'backup' in self.steps:
+            self._wrapped_output(
+                role           = 'Observations # CCMA',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = 'odb',
+                kind           = 'observations',
+                layout         = 'ccma',
+                local          = '[layout:upper]',
+                part           = 'mix',
+                stage          = 'minim',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'Observations # ALL',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = 'odb',
+                kind           = 'observations',
+                local          = 'ECMA.{glob:ext:\w+}',
+                part           = '[glob:ext]',
+                stage          = 'screening',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'Analysis',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = 'fa',
+                kind           = 'analysis',
+                local          = 'ICMSHMXMI+0000',
+                namespace      = self.REF_OUTPUT,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'VarBC # OUT',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = 'ascii',
+                kind           = 'varbc',
+                local          = 'VARBC.cycle',
+                stage          = 'screening',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 3.0.1/ Davai expertise:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_expertise())
+            self._wrapped_output(**self._output_comparison_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 3.0.2/ Other output resources of possible interest:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_listing())
+            self._wrapped_output(**self._output_stdeo())
+            self._wrapped_output(**self._output_drhook_profiles())
+            #-------------------------------------------------------------------------------
+

--- a/src/tasks/build/gmkpack/bundle2pack.py
+++ b/src/tasks/build/gmkpack/bundle2pack.py
@@ -51,7 +51,7 @@ class Bundle2Pack(Task, DavaiTaskMixin, GmkpackMixin):
             else:
                 # TODO: use git provider when available
                 IALbundles = TmpIALbundleRepo(self.conf.IAL_bundle_repository, verbose=True)
-                b = IALbundles.get_bundle(self.IAL_bundle_ref, to_file='__tmp__')
+                b = IALbundles.get_bundle(self.conf.IAL_bundle_ref, to_file='__tmp__')
                 bundle_provider['remote'] = b.bundle_file
             self._wrapped_input(
                 role           = 'Bundle',

--- a/src/tasks/conf/ELP.yaml
+++ b/src/tasks/conf/ELP.yaml
@@ -20,6 +20,7 @@ assim:
     # arome
     - arome_BSM3DVar_CNT0  # BSM = Bator+Screening+Minim
     - arome_BA3DVar_OOPS  # BA = Bator+Analysis (all-in-one)
+    - arome_BA3DEnVar_OOPS  # BA = Bator+Analysis (all-in-one)
     - arome_BSM3DVar_OOPS  # BSM = Bator+Screening+Minim
     # one obstype at a time -- Bator+Screening only
     - arpege_BS3D__obstype

--- a/src/tasks/conf/NRV.yaml
+++ b/src/tasks/conf/NRV.yaml
@@ -11,13 +11,14 @@ forecasts:
 
 assim:
     # arpege
-    - arpege_BSHM4DVar_OOPS  # BSHM = Bator+Screening+H(TL/AD)+Minim
     - arpege_BA4DVar_OOPS  # BA = Bator+Analysis (all-in-one)
+    - arpege_BSHM4DVar_OOPS  # BSHM = Bator+Screening+H(TL/AD)+Minim
     - arpege_BSM4DVar_CNT0  # BSM = Bator+Screening+Minim
     - arpege_BC  # BC = Bator(surf)+Canari
     # arome
     - arome_BSM3DVar_CNT0  # BSM = Bator+Screening+Minim
     - arome_BA3DVar_OOPS  # BA = Bator+Analysis (all-in-one)
+    - arome_BA3DEnVar_OOPS  # BA = Bator+Analysis (all-in-one)
 
 oops:
     - Bmat_arpege  # Construction and reading of a B-matrix using an ensemble, EnVar unit tests

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -14,7 +14,7 @@ uenv_gdata_detour   = davai_gmirror
 # static resources : uenv/genv
 davaienv            = uenv:cy50t1.davai_specials.04@davai
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.04@davai
-appenv_lam          = uenv:cy50t1.LAM@davai.07@davai
+appenv_lam          = uenv:cy50t1.LAM@davai.08@vogtv
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.01@davai
 appenv_clim         = uenv:cy50t1_clim.02@davai
 commonenv           = ${appenv_global}
@@ -592,6 +592,19 @@ geometry            = geometry(france10km)
 timestep            = 60
 # several rundates to cover the whole span of obstypes
 rundates            = 2025030912,2025030915,2025030921,2025031003,2025031006
+discard_obstype     = radar1
+# profile (ntasks = ntasks/node)
+time                = 00:40:00
+ntasks              = 16
+nnodes              = 1
+openmp              = 8
+
+[arome_BA3DEnVar_OOPS]
+geometry            = geometry(france10km)
+timestep            = 60
+# several rundates to cover the whole span of obstypes
+rundates            = 2025030912,2025030915,2025030921,2025031003,2025031006
+members             = 8
 discard_obstype     = radar1
 # profile (ntasks = ntasks/node)
 time                = 00:40:00

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -8,7 +8,7 @@ ref_vconf           = elp
 # static resources : uenv/genv
 davaienv            = uenv:cy50t1.davai_specials.04@davai
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.04@davai
-appenv_lam          = uenv:cy50t1.LAM@davai.07@davai
+appenv_lam          = uenv:cy50t1.LAM@davai.08@vogtv
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.01@davai
 appenv_clim         = uenv:cy50t1_clim.02@davai
 commonenv           = ${appenv_global}
@@ -585,6 +585,19 @@ geometry            = geometry(france10km)
 timestep            = 60
 # several rundates to cover the whole span of obstypes
 rundates            = 2025030912,2025030915,2025030921,2025031003,2025031006
+discard_obstype     = radar1
+# profile (ntasks = ntasks/node)
+time                = 00:40:00
+ntasks              = 16
+nnodes              = 1
+openmp              = 8
+
+[arome_BA3DEnVar_OOPS]
+geometry            = geometry(france10km)
+timestep            = 60
+# several rundates to cover the whole span of obstypes
+rundates            = 2025030912,2025030915,2025030921,2025031003,2025031006
+members             = 8
 discard_obstype     = radar1
 # profile (ntasks = ntasks/node)
 time                = 00:40:00


### PR DESCRIPTION
Add 3DEnVar+SDL analysis in NRV and ELP usecases

requirements :

uenv pushed : cy50t1.LAM@davai.08@vogtv (2 jsons files added : 3DEnVar and 3DEnVarSDL)
or directly on belenos : 
/home/gmap/mrpa/vogtv/.vortexrc/hack/uget/vogtv/data/config50t1.oops@davai.04c/analyse-3DEnVar_aro.json
/home/gmap/mrpa/vogtv/.vortexrc/hack/uget/vogtv/data/config50t1.oops@davai.04c/analyse-3DEnVarSDL_aro.json


shelf : perturbations needed for EnVar
available on belenos : /scratch/work/vogtv/davai/shelf_cy50.02@vogtv
or (tarfile) on hendrix : /home/vogtv/gmap/shelf_cy50.02@vogtv.tar
