### PR TITLE
Miscellaneous additions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies=[
     "pyyaml",
     "bronx",
     "epygram==2.0.4",
-    "ial_build==1.3.4",
-    "ial_expertise==1.2.7",
+    "ial_build==1.4.0",
+    "ial_expertise==1.3.0",
     "matplotlib",  # FIXME: remove when bronx>2.0.0 does not fail on matplotlib import
     #"vortex",
     # indirect dependencies from vortex, to remove with vortex-2:

--- a/src/davai/vtx/algo/mixins.py
+++ b/src/davai/vtx/algo/mixins.py
@@ -12,7 +12,7 @@ from common.algo.oopsroot import OOPSAnalysis, OOPSAnalysisWithScreening
 from common.algo.assim import (Screening, Minim, Canari)
 from common.algo.odbtools import (Raw2ODBparallel)
 from common.algo.forecasts import (Forecast, LAMForecast, DFIForecast,
-                                   FullPosBDAP, FullPosGeo)
+                                   FullPosBDAP, FullPosGeo, MUSCForecast)
 from common.algo.clim import (BuildPGD, BuildPGD_MPI, C923)
 from common.algo.coupling import Coupling, Prep
 from common.algo.fpserver import FullPosServer
@@ -167,3 +167,8 @@ class Coupling_CrashWitness(Coupling, _CrashWitnessDecoMixin):
 
 class Canari_CrashWitness(Canari, _CrashWitnessDecoMixin):
     pass
+
+
+class MUSCForecast_CrashWitness(MUSCForecast, _CrashWitnessDecoMixin):
+    pass
+

--- a/src/tasks/clim/c923.py
+++ b/src/tasks/clim/c923.py
@@ -13,7 +13,7 @@ from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
 
 class C923(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'clim_model'}),]
     _taskinfo_kind = 'statictaskinfo'
 
     def process(self):

--- a/src/tasks/clim/finalize_pgd.py
+++ b/src/tasks/clim/finalize_pgd.py
@@ -13,7 +13,7 @@ from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
 
 class FinalizePGD(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'clim_model'}),]
     _taskinfo_kind = 'statictaskinfo'
 
     def process(self):

--- a/src/tasks/clim/make_lam_domain.py
+++ b/src/tasks/clim/make_lam_domain.py
@@ -13,7 +13,7 @@ from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
 
 class MakeLamDomain(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = []  # [FPDict({'kind':'fields_in_file'})]
+    experts = []
     _taskinfo_kind = 'statictaskinfo'
 
     def geom_params(self):

--- a/src/tasks/conf/ELP.yaml
+++ b/src/tasks/conf/ELP.yaml
@@ -9,6 +9,15 @@ forecasts:
     # canonical forecasts = close to operations, including extra components
     - canonical_arpege_global798c22
     - mitra_global31c1
+    - mitra_global30c24_hyd_adiab
+    - mitra_global30c24_nhe_adiab
+    - mitra_global30c24_nhq_adiab
+    - mitra_global30c24_hyd_arpphy
+    - mitra_global30c24_nhe_arpphy
+    - mitra_global30c24_nhq_arpphy
+    - mitra_lam_hyd_adiab
+    - mitra_lam_nhe_adiab
+    - mitra_lam_nhq_adiab
 
 assim:
     # arpege

--- a/src/tasks/conf/ELP.yaml
+++ b/src/tasks/conf/ELP.yaml
@@ -8,6 +8,7 @@ forecasts:
     - standalone_ifs_global21
     # canonical forecasts = close to operations, including extra components
     - canonical_arpege_global798c22
+    - mitra_global31c1
 
 assim:
     # arpege

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -769,12 +769,116 @@ openmp              = 8
 [mitra_global31c1]
 geometry            = geometry(global31c1)
 model               = arpege
-ic_block            = init
 rundate             = 2005071500
 expertise_term      = 6
 # profile (ntasks = ntasks/node)
 time                = 00:20:00
-ntasks              = 16
-nnodes              = 2
-openmp              = 8
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_hyd_adiab]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 01:00:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_nhe_adiab]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_nhq_adiab]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_hyd_arpphy]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_nhe_arpphy]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_global30c24_nhq_arpphy]
+geometry            = geometry(global30c24)
+model               = arpege
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_lam_hyd_adiab]
+geometry            = geometry(portugal21km)
+model               = aladin
+rundate             = 2008012300
+expertise_term      = 3
+fcst_term           = 3
+coupling_frequency  = 3
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_lam_nhe_adiab]
+geometry            = geometry(occitanie4km)
+model               = aladin
+rundate             = 2001061400
+expertise_term      = 3
+fcst_term           = 3
+coupling_frequency  = 3
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[mitra_lam_nhq_adiab]
+geometry            = geometry(occitanie4km)
+model               = aladin
+rundate             = 2001061400
+expertise_term      = 3
+fcst_term           = 3
+coupling_frequency  = 3
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
 

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -765,3 +765,16 @@ time                = 02:00:00
 ntasks              = 16
 nnodes              = 1
 openmp              = 8
+
+[mitra_global31c1]
+geometry            = geometry(global31c1)
+model               = arpege
+ic_block            = init
+rundate             = 2005071500
+expertise_term      = 6
+# profile (ntasks = ntasks/node)
+time                = 00:20:00
+ntasks              = 16
+nnodes              = 2
+openmp              = 8
+

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -61,6 +61,7 @@ cutoff              = assim
 rootpack            = /home/gmap/mrpe/mary/rootpack
 packtype            = incr
 compilation_flavours = list(IMPIIFCI2302REPRODP.y,IMPIIFCI2302REPROSP.y)
+#compilation_flavours = list(IMPIIFCI2302REPRODP.y,IMPIIFCI2302REPROSP.y,IMPIGFORT141MKL23DP50.x)
 # GMKPACK install: do not rely on user's
 GMKROOT = /home/gmap/mrpm/khatib/public/bin/gmkpack
 GMK_SUPPORT = /home/gmap/mrpm/khatib/public/bin/gmkpack_support
@@ -246,7 +247,7 @@ Ofrt                = 4
 optvcc              = -g -O2 -march=core-avx2
 regenerate_ics      = True
 default_programs    = masterodb,bator,ioassign,lfitools,pgd,prep,oovar,ootestvar
-programs_by_flavour = dict(IMPIIFCI2302REPROSP.y:list(lfitools,masterodb) IMPIIFCI2302REPRODP.ybc:list(lfitools,masterodb))
+programs_by_flavour = dict(IMPIIFCI2302REPROSP.y:list(lfitools,masterodb) IMPIIFCI2302REPRODP.ybc:list(lfitools,masterodb) IMPIGFORT141MKL23DP50.x:list(lfitools,masterodb))
 fatal_build_failure = __any__
 
 [wait4build]

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -234,7 +234,7 @@ timestep            = 90
 rundate             = 19970621T11:30
 geometry            = geometry(armcu)
 fcst_term           = 14
-expertise_term      = 14
+expertise_term      = list(0,13)
 suite_vapp          = musc
 suite_vconf         = armcu
 

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -424,7 +424,6 @@ openmp              = 4
 [armcu]
 pgd_source          = static
 surf_ic_source      = static
-model_configs       = list(arome_nominal,arome_nosfx,arpege_nominal,arpege_nosfx)
 # profile (ntasks = ntasks/node)
 time                = 01:00:00
 ntasks              = 1
@@ -434,7 +433,6 @@ openmp              = 1
 [armcu_PPM]
 pgd_source          = flow
 surf_ic_source      = flow
-model_configs       = list(arome_nominal,arpege_nominal)
 # profile (ntasks = ntasks/node)
 time                = 01:00:00
 ntasks              = 1

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -341,6 +341,7 @@ bundle_src_dir      = $HOME/bundle_cache
 rundate             = 2020081800
 namelist_components = list(spnorms.nam,FPinline_6h.nam)
 suite_vconf         = 4dvarfr
+pp_area             = list(atourx01,eurat01,eurat1s20,glob01,glob025)
 # profile (ntasks = ntasks/node)
 time                = 01:00:00
 ntasks              = 32

--- a/src/tasks/forecasts/canonical/arpege.py
+++ b/src/tasks/forecasts/canonical/arpege.py
@@ -72,6 +72,7 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 role           = 'Reference',  # GRIB
                 block          = self.output_block(),
                 experiment     = self.conf.ref_xpid,
+                fatal          = False,
                 geometry       = self.conf.pp_area,
                 kind           = 'gridpoint',
                 local          = 'ref.GRIBPFFCST[geometry:tag:upper]+[term:fmthm]',
@@ -79,20 +80,19 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 origin         = 'historic',
                 term           = self.conf.expertise_term,
                 vconf          = self.conf.ref_vconf,
-                fatal          = True,
             )
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'Reference',  # DDH
                 block          = self.output_block(),
                 experiment     = self.conf.ref_xpid,
+                fatal          = False,
                 nativefmt      = 'lfa',
                 kind           = 'ddh',
                 local          = 'ref.DHFZOFCST+[term:fmth]',
                 term           = self.conf.expertise_term,
                 scope          = 'zonal',
                 vconf          = self.conf.ref_vconf,
-                fatal          = True,
             )
             #-------------------------------------------------------------------------------
 

--- a/src/tasks/forecasts/canonical/arpege.py
+++ b/src/tasks/forecasts/canonical/arpege.py
@@ -20,7 +20,10 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                FPDict({'expert':'fields_in_file', 'kind':'historic'}),
+                # FIXME: issue with multiple fields appearing with the same fid
+                # FPDict({'expert':'fields_in_file', 'kind':'gridpoint', 'parallel':True}),
+                FPDict({'expert':'fields_in_file', 'kind':'ddh'}),
                 ] + davai.vtx.util.default_experts()
 
     def process(self):
@@ -63,6 +66,33 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 nativefmt      = 'fa',
                 term           = self.conf.expertise_term,
                 vconf          = self.conf.ref_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # GRIB
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                geometry       = self.conf.pp_area,
+                kind           = 'gridpoint',
+                local          = 'ref.GRIBPFFCST[geometry:tag:upper]+[term:fmthm]',
+                nativefmt      = 'grib',
+                origin         = 'historic',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+                fatal          = True,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # DDH
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                nativefmt      = 'lfa',
+                kind           = 'ddh',
+                local          = 'ref.DHFZOFCST+[term:fmth]',
+                term           = self.conf.expertise_term,
+                scope          = 'zonal',
+                vconf          = self.conf.ref_vconf,
+                fatal          = True,
             )
             #-------------------------------------------------------------------------------
 
@@ -231,7 +261,7 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             self.sh.title('Toolbox algo = tbalgo')
             tbalgo = toolbox.algo(
                 crash_witness  = True,
-                ddhpack        = True,
+                ddhpack        = False,
                 drhookprof     = self.conf.drhook_profiling,
                 engine         = 'parallel',
                 fcterm         = self.conf.fcst_term,
@@ -278,14 +308,30 @@ class CanonicalArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             )
             #-------------------------------------------------------------------------------
             self._wrapped_output(
+                role           = 'Gridpoint',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                geometry       = '[glob:area]',
+                kind           = 'gridpoint',
+                local          = 'GRIBPFFCST{glob:area:\w+}+{glob:term:\d+(?::\d+)?}',
+                namespace      = self.REF_OUTPUT,
+                nativefmt      = 'grib',
+                origin         = 'historic',
+                term           = '[glob:term]',
+                fatal          = False
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
                 role           = 'DDH',
                 block          = self.output_block(),
                 experiment     = self.conf.xpid,
-                format         = 'ddhpack',
+                nativefmt      = 'lfa',
                 kind           = 'ddh',
-                local          = 'ddhpack_{glob:s:\w+}',
-                nativefmt      = '[format]',
-                scope          = '[glob:s]',
+                local          = 'DHFZOFCST+{glob:term:\d+(?::\d+)?}',
+                term           = '[glob:term]',
+                namespace      = self.REF_OUTPUT,
+                scope          = 'zonal',
+                fatal          = False
             )
             #-------------------------------------------------------------------------------
 

--- a/src/tasks/forecasts/mitra/arpege.py
+++ b/src/tasks/forecasts/mitra/arpege.py
@@ -18,7 +18,7 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                #FPDict({'kind':'fields_in_file'})
+                #FPDict({'expert':'fields_in_file', 'kind':'historic'}),  # should we ?
                 ] + davai.vtx.util.default_experts()
 
     @property

--- a/src/tasks/forecasts/mitra/arpege.py
+++ b/src/tasks/forecasts/mitra/arpege.py
@@ -18,7 +18,7 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                #FPDict({'kind':'fields_in_file'})
                 ] + davai.vtx.util.default_experts()
 
     @property
@@ -45,18 +45,18 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             self._wrapped_input(**self._reference_continuity_expertise())
             self._wrapped_input(**self._reference_continuity_listing())
             #-------------------------------------------------------------------------------
-            self._wrapped_input(
-                role           = 'Reference',  # ModelState (continuity)
-                block          = self.output_block(),
-                experiment     = self.conf.ref_xpid,
-                fatal          = False,
-                format         = '[nativefmt]',
-                kind           = 'historic',
-                local          = 'ref.ICMSHARPE+[term:fmthm]',
-                nativefmt      = 'fa',
-                term           = self.conf.expertise_term,
-                vconf          = self.conf.ref_vconf,
-            )
+            #self._wrapped_input(
+            #    role           = 'Reference',  # ModelState (continuity)
+            #    block          = self.output_block(),
+            #    experiment     = self.conf.ref_xpid,
+            #    fatal          = False,
+            #    format         = '[nativefmt]',
+            #    kind           = 'historic',
+            #    local          = 'ref.ICMSHARPE+[term:fmthm]',
+            #    nativefmt      = 'fa',
+            #    term           = self.conf.expertise_term,
+            #    vconf          = self.conf.ref_vconf,
+            #)
             #-------------------------------------------------------------------------------
         if 'fetch' in self.steps:
             # this task is also to be compared to another task of the same experiment

--- a/src/tasks/forecasts/mitra/arpege.py
+++ b/src/tasks/forecasts/mitra/arpege.py
@@ -21,6 +21,15 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 FPDict({'kind':'fields_in_file'})
                 ] + davai.vtx.util.default_experts()
 
+    @property
+    def _ic_block(self):
+        if '_nhe_' in self._configtag or '_nhq_' in self._configtag:
+            return 'nh'
+        elif '_sprtgpq_' in self._configtag:
+            return 'gpq'
+        else:
+            return 'hyd'
+
     def process(self):
         self._wrapped_init()
         self._notify_start_inputs()
@@ -58,6 +67,7 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
         if 'early-fetch' in self.steps or 'fetch' in self.steps:
             self._load_usual_tools()  # LFI tools, ecCodes defs, ...
             #-------------------------------------------------------------------------------
+            # only for jobs with radiation
             self._wrapped_input(
                 role           = 'RrtmConst',
                 format         = 'unknown',
@@ -104,7 +114,7 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'Atmospheric Initial Conditions',
-                block          = self.conf.ic_block,
+                block          = self._ic_block,
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',

--- a/src/tasks/forecasts/mitra/arpege.py
+++ b/src/tasks/forecasts/mitra/arpege.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+
+from footprints import FPDict
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Task
+from common.util.hooks import update_namelist
+import davai
+
+from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
+from davai.vtx.hooks.namelists import hook_gnam
+
+
+class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
+
+    @property
+    def experts(self):
+        """Redefinition as property because of runtime/conf-determined values."""
+        return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
+                FPDict({'kind':'fields_in_file'})
+                ] + davai.vtx.util.default_experts()
+
+    def process(self):
+        self._wrapped_init()
+        self._notify_start_inputs()
+
+        # 0./ Promises
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_promise(**self._promised_listing())
+            self._wrapped_promise(**self._promised_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 1.1.0/ Reference resources, to be compared to:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(**self._reference_continuity_expertise())
+            self._wrapped_input(**self._reference_continuity_listing())
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # ModelState (continuity)
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ref.ICMSHARPE+[term:fmthm]',
+                nativefmt      = 'fa',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
+            #-------------------------------------------------------------------------------
+        if 'fetch' in self.steps:
+            # this task is also to be compared to another task of the same experiment
+            self._wrapped_input(**self._reference_consistency_expertise())
+            self._wrapped_input(**self._reference_consistency_listing())
+
+        # 1.1.1/ Static Resources:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._load_usual_tools()  # LFI tools, ecCodes defs, ...
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RrtmConst',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rrtm',
+                local          = 'rrtm.const.tgz',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.2/ Static Resources (namelist(s) & config):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            tbport = self._wrapped_input(
+                role           = 'PortabilityNamelist',
+                kind           = 'namelist',
+                local          = 'portability.nam',
+                path           = f'namelist/davai/portability/{self.conf.target_host}.nam',
+                ref            = self.conf.gitenv_ref,
+                repo           = self.conf.gitenv_repo,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Namelist',
+                hook_options   = (update_namelist, tbport),
+                hook_conf      = (hook_gnam, self.conf.get('nam_hook', {})),
+                #hook_z         = (hook_gnam, {'NAMBLOCK':{'LKEY':True, RVALUE:0.}}),
+                intent         = 'inout',
+                kind           = 'namelist',
+                local          = 'fort.4',
+                path           = f'namelist/mitra/global/{self._configtag.upper()}.nam',
+                ref            = self.conf.gitenv_ref,
+                repo           = self.conf.gitenv_repo,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.3/ Static Resources (executables):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            tbx = self.flow_executable(kind='mfmodel')
+            #-------------------------------------------------------------------------------
+
+        # 1.2/ Flow Resources (initial): theoretically flow-resources, but statically stored in input_shelf
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Atmospheric Initial Conditions',
+                block          = self.conf.ic_block,
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                format         = '[nativefmt]',
+                kind           = 'initial_condition',
+                local          = 'ICMSHARPEINIT',
+                nativefmt      = 'fa',
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 2.1/ Flow Resources: produced by another task of the same job
+        if 'fetch' in self.steps:
+            pass
+            #-------------------------------------------------------------------------------
+
+        self._notify_inputs_done()
+        # 2.2/ Compute step
+        if 'compute' in self.steps:
+            self._notify_start_compute()
+            self.sh.title('Toolbox algo = tbalgo')
+            tbalgo = toolbox.algo(
+                crash_witness  = True,
+                drhookprof     = self.conf.drhook_profiling,
+                engine         = 'parallel',
+                kind           = 'forecast',
+                #fcterm         = self.conf.fcst_term,
+                #fcunit         = 'h',
+                #timestep       = self.conf.timestep,
+            )
+            print(self.ticket.prompt, 'tbalgo =', tbalgo)
+            print()
+            self.component_runner(tbalgo, tbx)
+            #-------------------------------------------------------------------------------
+            self.run_expertise()
+            #-------------------------------------------------------------------------------
+
+        # 2.3/ Flow Resources: produced by this task and possibly used by a subsequent flow-dependant task
+        if 'backup' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'ModelState',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ICMSHARPE+{glob:term:\d+(?::\d+)?}',
+                namespace      = self.REF_OUTPUT,
+                nativefmt      = 'fa',
+                term           = '[glob:term]',
+                fatal          = False
+            )
+            #-------------------------------------------------------------------------------
+
+        # 3.0.1/ Davai expertise:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_expertise())
+            self._wrapped_output(**self._output_comparison_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 3.0.2/ Other output resources of possible interest:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_listing())
+            self._wrapped_output(**self._output_stdeo())
+            self._wrapped_output(**self._output_drhook_profiles())
+            #-------------------------------------------------------------------------------
+

--- a/src/tasks/forecasts/mitra/lam.py
+++ b/src/tasks/forecasts/mitra/lam.py
@@ -19,7 +19,7 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                #FPDict({'kind':'fields_in_file'})
+                #FPDict({'expert':'fields_in_file', 'kind':'historic'}),  # should we ?
                 ] + davai.vtx.util.default_experts()
 
     @property
@@ -46,17 +46,17 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             self._wrapped_input(**self._reference_continuity_expertise())
             self._wrapped_input(**self._reference_continuity_listing())
             #-------------------------------------------------------------------------------
-            #self._wrapped_input(
-            #    role           = 'Reference',  # ModelState (continuity)
-            #    block          = self.output_block(),
-            #    experiment     = self.conf.ref_xpid,
-            #    fatal          = False,
-            #    kind           = 'historic',
-            #    local          = 'ref.ICMSHARPE+[term:fmthm]',
-            #    nativefmt      = 'fa',
-            #    term           = self.conf.expertise_term,
-            #    vconf          = self.conf.ref_vconf,
-            #)
+            self._wrapped_input(
+                role           = 'Reference',  # ModelState (continuity)
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                kind           = 'historic',
+                local          = 'ref.ICMSHARPE+[term:fmthm]',
+                nativefmt      = 'fa',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
             #-------------------------------------------------------------------------------
         if 'fetch' in self.steps:
             # this task is also to be compared to another task of the same experiment
@@ -172,9 +172,6 @@ class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 engine         = 'parallel',
                 kind           = 'lamfc',
                 xpname         = 'ARPE',
-                #fcterm         = self.conf.fcst_term,
-                #fcunit         = 'h',
-                #timestep       = self.conf.timestep,
             )
             print(self.ticket.prompt, 'tbalgo =', tbalgo)
             print()

--- a/src/tasks/forecasts/mitra/lam.py
+++ b/src/tasks/forecasts/mitra/lam.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+
+from footprints import FPDict
+from footprints.util import rangex
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Task
+from common.util.hooks import update_namelist
+import davai
+
+from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
+from davai.vtx.hooks.namelists import hook_gnam
+
+
+class Forecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
+
+    @property
+    def experts(self):
+        """Redefinition as property because of runtime/conf-determined values."""
+        return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
+                #FPDict({'kind':'fields_in_file'})
+                ] + davai.vtx.util.default_experts()
+
+    @property
+    def _ic_block(self):
+        if '_nhe_' in self._configtag or '_nhq_' in self._configtag:
+            return 'init_nh'
+        elif '_sprtgpq_' in self._configtag:
+            return 'init_gpq'
+        else:
+            return 'init_hyd'
+
+    def process(self):
+        self._wrapped_init()
+        self._notify_start_inputs()
+
+        # 0./ Promises
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_promise(**self._promised_listing())
+            self._wrapped_promise(**self._promised_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 1.1.0/ Reference resources, to be compared to:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(**self._reference_continuity_expertise())
+            self._wrapped_input(**self._reference_continuity_listing())
+            #-------------------------------------------------------------------------------
+            #self._wrapped_input(
+            #    role           = 'Reference',  # ModelState (continuity)
+            #    block          = self.output_block(),
+            #    experiment     = self.conf.ref_xpid,
+            #    fatal          = False,
+            #    kind           = 'historic',
+            #    local          = 'ref.ICMSHARPE+[term:fmthm]',
+            #    nativefmt      = 'fa',
+            #    term           = self.conf.expertise_term,
+            #    vconf          = self.conf.ref_vconf,
+            #)
+            #-------------------------------------------------------------------------------
+        if 'fetch' in self.steps:
+            # this task is also to be compared to another task of the same experiment
+            self._wrapped_input(**self._reference_consistency_expertise())
+            self._wrapped_input(**self._reference_consistency_listing())
+
+        # 1.1.1/ Static Resources:
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._load_usual_tools()  # LFI tools, ecCodes defs, ...
+            #-------------------------------------------------------------------------------
+            # only for jobs with radiation
+            self._wrapped_input(
+                role           = 'RrtmConst',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rrtm',
+                local          = 'rrtm.const.tgz',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.2/ Static Resources (namelist(s) & config):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            tbport = self._wrapped_input(
+                role           = 'PortabilityNamelist',
+                kind           = 'namelist',
+                local          = 'portability.nam',
+                path           = f'namelist/davai/portability/{self.conf.target_host}.nam',
+                ref            = self.conf.gitenv_ref,
+                repo           = self.conf.gitenv_repo,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Namelist',
+                hook_options   = (update_namelist, tbport),
+                hook_conf      = (hook_gnam, self.conf.get('nam_hook', {})),
+                #hook_z         = (hook_gnam, {'NAMBLOCK':{'LKEY':True, RVALUE:0.}}),
+                intent         = 'inout',
+                kind           = 'namelist',
+                local          = 'fort.4',
+                path           = f'namelist/mitra/lam/{self._configtag.upper()}.nam',
+                ref            = self.conf.gitenv_ref,
+                repo           = self.conf.gitenv_repo,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.3/ Static Resources (executables):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            tbx = self.flow_executable(kind='mfmodel')
+            #-------------------------------------------------------------------------------
+
+        # 1.2/ Flow Resources (initial): theoretically flow-resources, but statically stored in input_shelf
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Atmospheric Initial Conditions',
+                block          = 'init',  # self._ic_block,
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                kind           = 'initial_condition',
+                local          = 'ICMSHARPEINIT',
+                nativefmt      = 'fa',
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'BoundaryConditions',  # Initial
+                block          = 'coupling',
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                kind           = 'boundary',
+                local          = 'CPLIN+START',
+                nativefmt      = 'fa',
+                source_app     = 'arpege',
+                source_conf    = '4dvarfr',
+                term           = 0,
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'BoundaryConditions',
+                block          = 'coupling',
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                kind           = 'boundary',
+                local          = 'CPLIN+[term::fmthm]',
+                nativefmt      = 'fa',
+                source_app     = 'arpege',
+                source_conf    = '4dvarfr',
+                term           = rangex(self.conf.coupling_frequency, self.conf.fcst_term,
+                                        self.conf.coupling_frequency),
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 2.1/ Flow Resources: produced by another task of the same job
+        if 'fetch' in self.steps:
+            pass
+            #-------------------------------------------------------------------------------
+
+        self._notify_inputs_done()
+        # 2.2/ Compute step
+        if 'compute' in self.steps:
+            self._notify_start_compute()
+            self.sh.title('Toolbox algo = tbalgo')
+            tbalgo = toolbox.algo(
+                crash_witness  = True,
+                drhookprof     = self.conf.drhook_profiling,
+                engine         = 'parallel',
+                kind           = 'lamfc',
+                xpname         = 'ARPE',
+                #fcterm         = self.conf.fcst_term,
+                #fcunit         = 'h',
+                #timestep       = self.conf.timestep,
+            )
+            print(self.ticket.prompt, 'tbalgo =', tbalgo)
+            print()
+            self.component_runner(tbalgo, tbx)
+            #-------------------------------------------------------------------------------
+            self.run_expertise()
+            #-------------------------------------------------------------------------------
+
+        # 2.3/ Flow Resources: produced by this task and possibly used by a subsequent flow-dependant task
+        if 'backup' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'ModelState',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ICMSHARPE+{glob:term:\d+(?::\d+)?}',
+                namespace      = self.REF_OUTPUT,
+                nativefmt      = 'fa',
+                term           = '[glob:term]',
+                fatal          = False
+            )
+            #-------------------------------------------------------------------------------
+
+        # 3.0.1/ Davai expertise:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_expertise())
+            self._wrapped_output(**self._output_comparison_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 3.0.2/ Other output resources of possible interest:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_listing())
+            self._wrapped_output(**self._output_stdeo())
+            self._wrapped_output(**self._output_drhook_profiles())
+            #-------------------------------------------------------------------------------
+

--- a/src/tasks/forecasts/mitra_global30c24_hyd_adiab.py
+++ b/src/tasks/forecasts/mitra_global30c24_hyd_adiab.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCST_HYD_EUL_VFD_ADIAB_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_RVFE_ADIAB_SETTLS_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_EXTCLA_VESL_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_EXTCLA_XIDT_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_PCF_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_VESL_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_MSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_NDPSFI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_OSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_RW2TLFF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SPRTGPQ_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SPRTSPQ_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFE_ADIAB_SETTLS_NDEC_RW2TLFF_RFRIC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFE_ADIAB_SETTLS_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL3_VFD_ADIAB_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_EUL_VFD_ADIAB_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_RVFE_ADIAB_SETTLS_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_EXTCLA_VESL_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_EXTCLA_XIDT_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_PCF_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_VESL_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_MSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_NDPSFI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_OSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_RW2TLFF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SPRTGPQ_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SPRTSPQ_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_SSLHD_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFE_ADIAB_SETTLS_NDEC_RW2TLFF_RFRIC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFE_ADIAB_SETTLS_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL3_VFD_ADIAB_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global30c24_hyd_arpphy.py
+++ b/src/tasks/forecasts/mitra_global30c24_hyd_arpphy.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCTI_HYD_EUL_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFD_ARPPHYISBA_SETTLS_XIDT_NDPSFI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL2_VFE_ARPPHYISBA_SETTLS_NDEC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL3_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global30c24_nhe_adiab.py
+++ b/src/tasks/forecasts/mitra_global30c24_nhe_adiab.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCST_NHE_SL2_VFD_ADIAB_GWADV5_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_EUL_VFD_ADIAB_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_EUL_VFD_ADIAB_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_GWADV2_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_NGWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_RDBBC2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_RDBBC2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ADIAB_RDBBC2_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFE_ADIAB_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFE_ADIAB_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFE_ADIAB_NGWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL3_VFD_ADIAB_RDBBC2_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global30c24_nhe_arpphy.py
+++ b/src/tasks/forecasts/mitra_global30c24_nhe_arpphy.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCTI_NHE_EUL_VFD_ARPPHYISBA_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_EUL_VFD_ARPPHYISBA_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ARPPHYISBA_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL2_VFD_ARPPHYISBA_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHE_SL3_VFD_ARPPHYISBA_RDBBC2_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global30c24_nhq_adiab.py
+++ b/src/tasks/forecasts/mitra_global30c24_nhq_adiab.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFD_ADIAB_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFD_ADIAB_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFD_ADIAB_GWADV2_SI_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFE_ADIAB_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFE_ADIAB_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global30c24_nhq_arpphy.py
+++ b/src/tasks/forecasts/mitra_global30c24_nhq_arpphy.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFD_ARPPHYISBA_GWADV2_PCC_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_NHQ_SL2_VFD_ARPPHYISBA_GWADV2_PCF_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_global31c1.py
+++ b/src/tasks/forecasts/mitra_global31c1.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from footprints import FPDict
-
-import vortex
-from vortex import toolbox
 from vortex.layout.nodes import Family, Driver, LoopFamily
-from common.util.hooks import update_namelist
-import davai
 
 from .mitra.arpege import Forecast
 
@@ -23,8 +17,12 @@ def setup(t, **kw):
                 loopconf='compilation_flavours',
                 loopsuffix='.{}',
                 nodes=[
-                    Forecast(tag='GM_FCTI_HYD_EUL_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
-                    Forecast(tag='GM_FCTI_HYD_SL3_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_EUL_VFD_ADIAB_TL031U', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_EXTCLA_VESL_TL031U', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_EXTCLA_XIDT_TL031U', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_VESL_TL031U', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL2_VFD_ADIAB_SETTLS_XIDT_TL031U', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCST_HYD_SL3_VFD_ADIAB_TL031U', ticket=t, on_error='delayed_fail', **kw),
                     ],
                 **kw
                 ),

--- a/src/tasks/forecasts/mitra_global31c1.py
+++ b/src/tasks/forecasts/mitra_global31c1.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from footprints import FPDict
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Family, Driver, LoopFamily
+from common.util.hooks import update_namelist
+import davai
+
+from .mitra.arpege import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='GM_FCTI_HYD_EUL_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='GM_FCTI_HYD_SL3_VFD_ARPPHYISBA_TL030S', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_lam_hyd_adiab.py
+++ b/src/tasks/forecasts/mitra_lam_hyd_adiab.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.lam import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='L3_FCTI_HYD_EUL_VFD_ADIAB_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL3_VFD_ADIAB_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL3_VFE_ADIAB_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL3_VFD_ADIAB_SLHD_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL2_VFD_ADIAB_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL2_VFE_ADIAB_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_HYD_SL2_VFD_ADIAB_SLHD_PGAL', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_lam_nhe_adiab.py
+++ b/src/tasks/forecasts/mitra_lam_nhe_adiab.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.lam import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='L3_FCTI_NHE_EUL_VFD_ADIAB_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_NHE_SL3_VFD_ADIAB_RDBBC2_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFD_ADIAB_RDBBC2_PCC_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFD_ADIAB_RDBBC2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFD_ADIAB_GWADV2_PCC_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFD_ADIAB_GWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFE_ADIAB_GWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFD_ADIAB_NGWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCTI_NHE_SL2_VFE_ADIAB_NGWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCST_NHE_SL2_VFD_ADIAB_GWADV2_PCC_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    #Forecast(tag='L3_FCST_NHE_SL2_VFD_ADIAB_GWADV5_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/mitra_lam_nhq_adiab.py
+++ b/src/tasks/forecasts/mitra_lam_nhq_adiab.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .mitra.lam import Forecast
+
+
+def setup(t, **kw):
+    return Driver(
+        tag='drv',
+        ticket=t,
+        options=kw,
+        nodes=[
+            LoopFamily(
+                tag='gmkpack',
+                ticket=t,
+                loopconf='compilation_flavours',
+                loopsuffix='.{}',
+                nodes=[
+                    Forecast(tag='L3_FCTI_NHQ_SL2_VFD_ADIAB_GWADV2_PCC_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_NHQ_SL2_VFD_ADIAB_GWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    Forecast(tag='L3_FCTI_NHQ_SL2_VFE_ADIAB_GWADV2_PCF_FROC', ticket=t, on_error='delayed_fail', **kw),
+                    ],
+                **kw
+                ),
+            ]
+        )
+

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -19,7 +19,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                FPDict({'expert':'fields_in_file', 'kind':'historic'}),
                 ] + davai.vtx.util.default_experts()
 
     def process(self):

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -285,6 +285,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 kind           = 'lamfc',
                 fcterm         = self.conf.fcst_term,
                 fcunit         = 'h',
+                outputid       = 'none',  # fpos only but needed to replace macro in namelist
                 timestep       = self.conf.timestep,
             )
             print(self.ticket.prompt, 'tbalgo =', tbalgo)

--- a/src/tasks/forecasts/standalone/arome.py
+++ b/src/tasks/forecasts/standalone/arome.py
@@ -19,7 +19,7 @@ class StandaloneAromeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                FPDict({'expert':'fields_in_file', 'kind':'historic'}),
                 ] + davai.vtx.util.default_experts()
 
     def process(self):

--- a/src/tasks/forecasts/standalone/arome.py
+++ b/src/tasks/forecasts/standalone/arome.py
@@ -283,6 +283,7 @@ class StandaloneAromeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 kind           = 'lamfc',
                 fcterm         = self.conf.fcst_term,
                 fcunit         = 'h',
+                outputid       = 'none',  # fpos only but needed to replace macro in namelist
                 timestep       = self.conf.timestep,
             )
             print(self.ticket.prompt, 'tbalgo =', tbalgo)

--- a/src/tasks/forecasts/standalone/arpege.py
+++ b/src/tasks/forecasts/standalone/arpege.py
@@ -18,7 +18,7 @@ class StandaloneArpegeForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                FPDict({'expert':'fields_in_file', 'kind':'historic'}),
                 ] + davai.vtx.util.default_experts()
 
     def process(self):

--- a/src/tasks/forecasts/standalone/ifs.py
+++ b/src/tasks/forecasts/standalone/ifs.py
@@ -18,7 +18,7 @@ class StandaloneIFSForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                FPDict({'expert':'fields_in_file', 'kind':'historic'}),
                 ] + davai.vtx.util.default_experts()
 
     def process(self):

--- a/src/tasks/fullpos/arpege_lbc.py
+++ b/src/tasks/fullpos/arpege_lbc.py
@@ -16,7 +16,7 @@ class ArpegeLBCbyFullpos(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     @property
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
-        return [FPDict({'kind':'fields_in_file'}),
+        return [FPDict({'expert':'fields_in_file', 'kind':'boundary'}),
                 FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms})
                 ] + davai.vtx.util.default_experts()
 

--- a/src/tasks/fullpos/ifs_lbc.py
+++ b/src/tasks/fullpos/ifs_lbc.py
@@ -17,7 +17,7 @@ class IFS_LBCbyFullpos(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     @property
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
-        return [FPDict({'kind':'fields_in_file'}),
+        return [FPDict({'expert':'fields_in_file', 'kind':'boundary'}),
                 FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms})
                 ] + davai.vtx.util.default_experts()
 

--- a/src/tasks/musc/armcu.py
+++ b/src/tasks/musc/armcu.py
@@ -7,18 +7,14 @@ from .musc import MUSCForecast
 
 def setup(t, **kw):
     return Driver(tag='drv', ticket=t, options=kw, nodes=[
-        LoopFamily(tag='models', ticket=t,
-            loopconf='model_configs',
-            loopsuffix='.{}',
-            nodes=[
-                Family(tag='case_armcu', ticket=t, on_error='delayed_fail', nodes=[
-                    LoopFamily(tag='gmkpack', ticket=t,
-                        loopconf='compilation_flavours',
-                        loopsuffix='.{}',
-                        nodes=[
-                            MUSCForecast(tag='model', ticket=t, on_error='delayed_fail', **kw),
-                        ], **kw),
-                    ], **kw),
+        LoopFamily(tag='gmkpack', ticket=t, loopconf='compilation_flavours', loopsuffix='.{}', nodes=[
+            Family(tag='case_armcu', ticket=t, nodes=[
+                # tag must start with model_*
+                MUSCForecast(tag='arome_nominal', ticket=t, on_error='delayed_fail', **kw),
+                MUSCForecast(tag='arome_nosfx', ticket=t, on_error='delayed_fail', **kw),
+                MUSCForecast(tag='arpege_nominal', ticket=t, on_error='delayed_fail', **kw),
+                MUSCForecast(tag='arpege_nosfx', ticket=t, on_error='delayed_fail', **kw),
                 ], **kw),
+            ], **kw),
         ],
     )

--- a/src/tasks/musc/armcu_PPM.py
+++ b/src/tasks/musc/armcu_PPM.py
@@ -9,20 +9,18 @@ from .musc import MUSCForecast
 
 def setup(t, **kw):
     return Driver(tag='drv', ticket=t, options=kw, nodes=[
-        LoopFamily(tag='models', ticket=t,
-            loopconf='model_configs',
-            loopsuffix='.{}',
-            nodes=[
-                Family(tag='case_armcu', ticket=t, on_error='delayed_fail', nodes=[
-                    PGD(tag='pgd', ticket=t, **kw),
-                    Prep(tag='prep', ticket=t, **kw),
-                    LoopFamily(tag='gmkpack', ticket=t,
-                        loopconf='compilation_flavours',
-                        loopsuffix='.{}',
-                        nodes=[
-                            MUSCForecast(tag='model', ticket=t, on_error='delayed_fail', **kw),
-                        ], **kw),
-                    ], **kw),
+        Family(tag='default_compilation_flavour', ticket=t, nodes=[
+            Family(tag='case_armcu', ticket=t, nodes=[
+                PGD(tag='pgd', ticket=t, **kw),
+                Prep(tag='prep', ticket=t, **kw),
                 ], **kw),
-        ],
+            ], **kw),
+        LoopFamily(tag='gmkpack', ticket=t, loopconf='compilation_flavours', loopsuffix='.{}', nodes=[
+            Family(tag='case_armcu', ticket=t, nodes=[
+                # tag must start with model_*
+                MUSCForecast(tag='arome_nominal', ticket=t, on_error='delayed_fail', **kw),
+                MUSCForecast(tag='arpege_nominal', ticket=t, on_error='delayed_fail', **kw),
+                ], **kw),
+            ], **kw),
+        ]
     )

--- a/src/tasks/musc/musc.py
+++ b/src/tasks/musc/musc.py
@@ -18,7 +18,8 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                FPDict({'kind':'fields_in_file'})
+                #FPDict({'kind':'fields_in_file'}),  # FIXME: epygram not able to read them yet
+                FPDict({'kind':'ddh'})
                 ] + davai.vtx.util.default_experts()
 
     @property
@@ -37,30 +38,29 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
 
         # 1.1.0/ Reference resources, to be compared to:
-        #if 'early-fetch' in self.steps or 'fetch' in self.steps:
-            #self._wrapped_input(**self._reference_continuity_expertise())
-            #self._wrapped_input(**self._reference_continuity_listing())
-            ##-------------------------------------------------------------------------------
-            #self._wrapped_input(
-            #    role           = 'Reference',  # ModelState (continuity)
-            #    block          = self.output_block(),
-            #    experiment     = self.conf.ref_xpid,
-            #    fatal          = False,
-            #    format         = '[nativefmt]',
-            #    kind           = 'historic',
-            #    local          = 'ref.ICMSHFCST+[term:fmthm]',
-            #    model          = self.conf.model_config.split('_')[0]
-            #    nativefmt      = 'fa',
-            #    term           = self.conf.expertise_term,
-            #    vconf          = self.conf.ref_vconf,
-            #)
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_input(**self._reference_continuity_expertise())
+            self._wrapped_input(**self._reference_continuity_listing())
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # ModelState (continuity)
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ref.ICMSHARPE+[term:fmthm]',
+                model          = self.model,
+                nativefmt      = 'fa',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
             #-------------------------------------------------------------------------------
             #self._wrapped_input(
             #    role           = 'Reference',  # SurfState (continuity)
             #    block          = self.output_block(),
             #    experiment     = self.conf.ref_xpid,
             #    fatal          = False,
-            #    format         = '[nativefmt]',
             #    kind           = 'historic',
             #    local          = 'ref.ICMSHFCST+[term:fmthm].sfx',
             #    model          = 'surfex',
@@ -69,10 +69,20 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #    vconf          = self.conf.ref_vconf,
             #)
             ##-------------------------------------------------------------------------------
-        #if 'fetch' in self.steps:
-        #    # this task is also to be compared to another task of the same experiment
-        #    self._wrapped_input(**self._reference_consistency_expertise())
-        #    self._wrapped_input(**self._reference_consistency_listing())
+            # These are not exactly DDH but considered as such for the sake of the DDH expert comparison
+            self._wrapped_input(
+                role           = 'Reference',  # MUSC special output
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                kind           = 'ddh',
+                local          = 'ref.Out.[term:fmth].0000.lfa',  # 0000: we save (and compare) only round hours
+                model          = self.model,
+                nativefmt      = 'lfa',
+                scope          = 'dlimited',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
 
         # 1.1.1/ Static Resources:
         if 'early-fetch' in self.steps or 'fetch' in self.steps:
@@ -86,14 +96,6 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 local          = 'rrtm.const.tgz',
             )
             #-------------------------------------------------------------------------------
-            #self._wrapped_input(
-            #    role           = 'RtCoef',
-            #    format         = 'unknown',
-            #    genv           = self.conf.commonenv,
-            #    kind           = 'rtcoef',
-            #    local          = 'var.sat.misc_rtcoef.01.tgz',
-            #)
-            #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'CoverParams',
                 format         = 'foo',
@@ -106,22 +108,13 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             if self.conf.pgd_source == 'static':
                 self._wrapped_input(
                     role           = 'ClimPGD',
-                    format         = 'fa',
+                    nativefmt      = 'fa',
                     genv           = self.conf.davaienv,
                     gvar           = 'pgd_fa_[geometry::tag]',
                     kind           = 'pgdfa',
                     local          = 'Const.Clim.sfx',
                 )
-                # else: 2.1
-            #-------------------------------------------------------------------------------
-            #self._wrapped_input(
-            #    role           = 'Global Clim',
-            #    format         = 'fa',
-            #    genv           = self.conf.davaienv,
-            #    kind           = 'clim_model',
-            #    local          = 'Const.Clim',
-            #    month          = self.conf.rundate,
-            #)
+            # else: 2.1
             #-------------------------------------------------------------------------------
 
         # 1.1.2/ Static Resources (namelist(s) & config):
@@ -137,20 +130,8 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 repo           = self.conf.gitenv_repo,
             )
             #-------------------------------------------------------------------------------
-            # deactivate FPinline & DDH, activate spnorms:
-            #tboptions = self._wrapped_input(
-            #    role           = 'Namelist Deltas to add/remove options',
-            #    component      = self.conf.namelist_components,
-            #    kind           = 'namelist',
-            #    local          = '[component]',
-            #    path           = f'namelist/davai/[component]',
-            #    ref            = self.conf.gitenv_ref,
-            #    repo           = self.conf.gitenv_repo,
-            #)
-            #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'Namelist',
-                #hook_options   = (update_namelist, tboptions),
                 hook_conf      = (hook_gnam, self.conf.get('nam_hook', {})),
                 #hook_z         = (hook_gnam, {'NAMBLOCK':{'LKEY':True, RVALUE:0.}}),
                 intent         = 'inout',
@@ -208,7 +189,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                     role           = 'PGD',
                     block          = self.input_block('pgd'),
                     experiment     = self.conf.xpid,
-                    format         = 'fa',
+                    nativefmt      = 'fa',
                     kind           = 'pgdfa',
                     local          = 'Const.Clim.sfx',
                     model          = self.model,
@@ -221,7 +202,6 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                     block          = self.input_block('prep'),
                     date           = self.conf.rundate,
                     experiment     = self.conf.xpid,
-                    format         = '[nativefmt]',
                     filling        = 'surf',
                     kind           = 'ic',
                     local          = 'ICMSHARPEINIT.sfx',
@@ -240,10 +220,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 crash_witness  = True,
                 drhookprof     = self.conf.drhook_profiling,
                 engine         = 'parallel',
-                kind           = 'forecast',
-                #fcterm         = self.conf.fcst_term,
-                #fcunit         = 'h',
-                #timestep       = self.conf.timestep,
+                kind           = 'musc',
             )
             print(self.ticket.prompt, 'tbalgo =', tbalgo)
             print()
@@ -261,23 +238,39 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 experiment     = self.conf.xpid,
                 format         = '[nativefmt]',
                 kind           = 'historic',
-                local          = 'ICMSHFCST+{glob:term:\d+(?::\d+)?}',
+                local          = 'ICMSHARPE+{glob:term:\d+(?::\d+)?}',
+                model          = self.model,
                 namespace      = self.REF_OUTPUT,
                 nativefmt      = 'fa',
                 term           = '[glob:term]',
                 fatal          = False
             )
             #-------------------------------------------------------------------------------
+            #self._wrapped_output(
+            #    role           = 'SurfState',
+            #    block          = self.output_block(),
+            #    experiment     = self.conf.xpid,
+            #    format         = '[nativefmt]',
+            #    kind           = 'historic',
+            #    local          = 'ICMSHFCST+{glob:term:\d+(?::\d+)?}.sfx',
+            #    model          = 'surfex',
+            #    namespace      = self.REF_OUTPUT,
+            #    nativefmt      = 'fa',
+            #    term           = '[glob:term]',
+            #    fatal          = False
+            #)
+            #-------------------------------------------------------------------------------
+            # These are not exactly DDH but considered as such for the sake of the DDH expert comparison
             self._wrapped_output(
-                role           = 'SurfState',
+                role           = 'DDHoutput',
+                scope          = 'dlimited',
                 block          = self.output_block(),
                 experiment     = self.conf.xpid,
-                format         = '[nativefmt]',
-                kind           = 'historic',
-                local          = 'ICMSHFCST+{glob:term:\d+(?::\d+)?}.sfx',
-                model          = 'surfex',
+                kind           = 'ddh',
+                local          = 'Out.{glob:term:\d+}.0000.lfa',  # 0000: we save (and compare) only round hours
+                model          = self.model,
                 namespace      = self.REF_OUTPUT,
-                nativefmt      = 'fa',
+                nativefmt      = 'lfa',
                 term           = '[glob:term]',
                 fatal          = False
             )

--- a/src/tasks/musc/musc.py
+++ b/src/tasks/musc/musc.py
@@ -21,6 +21,11 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 FPDict({'kind':'fields_in_file'})
                 ] + davai.vtx.util.default_experts()
 
+    @property
+    def model(self):
+        """ASSUMES task tag starts with model !!!"""
+        return self._configtag.split('_')[0]
+
     def process(self):
         self._wrapped_init()
         self._notify_start_inputs()
@@ -151,8 +156,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 intent         = 'inout',
                 kind           = 'namelist',
                 local          = 'fort.4',
-                #path           = f'namelist/{self.conf.suite_vapp}/{self.conf.suite_vconf}/{self._configtag}.nam',
-                path           = f'namelist/{self.conf.suite_vapp}/{self.conf.suite_vconf}/{self.conf.model_config}.nam',
+                path           = f'namelist/{self.conf.suite_vapp}/{self.conf.suite_vconf}/{self._configtag}.nam',
                 ref            = self.conf.gitenv_ref,
                 repo           = self.conf.gitenv_repo,
             )
@@ -174,7 +178,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 experiment     = self.conf.input_shelf,
                 kind           = 'initial_condition',
                 local          = 'ICMSHARPEINIT',
-                model          = self.conf.model_config.split('_')[0],
+                model          = self.model,
                 nativefmt      = 'fa',
                 vapp           = self.conf.shelves_vapp,
                 vconf          = self.conf.shelves_vconf,
@@ -207,7 +211,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                     format         = 'fa',
                     kind           = 'pgdfa',
                     local          = 'Const.Clim.sfx',
-                    model          = self.conf.model_config.split('_')[0],
+                    model          = self.model,
                 )
                 # else: 1.1.1
             #-------------------------------------------------------------------------------

--- a/src/tasks/musc/musc.py
+++ b/src/tasks/musc/musc.py
@@ -18,7 +18,7 @@ class MUSCForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
     def experts(self):
         """Redefinition as property because of runtime/conf-determined values."""
         return [FPDict({'kind':'norms', 'hide_equal_norms':self.conf.hide_equal_norms}),
-                #FPDict({'kind':'fields_in_file'}),  # FIXME: epygram not able to read them yet
+                #FPDict({'expert':'fields_in_file', 'kind':'historic'}),  # FIXME: epygram not able to read them yet
                 FPDict({'kind':'ddh'})
                 ] + davai.vtx.util.default_experts()
 

--- a/src/tasks/musc/pgd.py
+++ b/src/tasks/musc/pgd.py
@@ -13,7 +13,7 @@ from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
 
 class MUSC_PGD(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'pgdfa'}),]
     _taskinfo_kind = 'statictaskinfo'
 
     def process(self):

--- a/src/tasks/musc/prep.py
+++ b/src/tasks/musc/prep.py
@@ -13,7 +13,7 @@ from davai.vtx.hooks.namelists import hook_gnam
 
 class MUSCPrep(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'initial_condition'}),]
 
     def process(self):
         self._wrapped_init()

--- a/src/tasks/oops/ModelTLAD_arpege.py
+++ b/src/tasks/oops/ModelTLAD_arpege.py
@@ -12,6 +12,7 @@ def setup(t, **kw):
             Family(tag='4dvar6h', ticket=t, nodes=[
                 Family(tag='default_compilation_flavour', ticket=t, nodes=[
                     ModelTLAD(tag='model_tlad', ticket=t, **kw),
+                    ModelTLAD(tag='model_tlad_adiab', ticket=t, **kw),
                     ], **kw),
                 ], **kw),
             ], **kw),

--- a/src/tasks/oops/bmat/BmatFlowDependent.py
+++ b/src/tasks/oops/bmat/BmatFlowDependent.py
@@ -16,7 +16,7 @@ from davai.vtx.hooks.namelists import hook_fix_model, hook_gnam, hook_disable_fu
 
 class Bmat(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})] + davai.vtx.util.default_experts()
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'historic'})] + davai.vtx.util.default_experts()
 
     def process(self):
         self._wrapped_init()

--- a/src/tasks/oops/bmat/BmatSimple.py
+++ b/src/tasks/oops/bmat/BmatSimple.py
@@ -16,7 +16,7 @@ from davai.vtx.hooks.namelists import hook_fix_model, hook_gnam, hook_disable_fu
 
 class Bmat(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})] + davai.vtx.util.default_experts()
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'historic'})] + davai.vtx.util.default_experts()
 
     def process(self):
         self._wrapped_init()

--- a/src/tasks/oops/bmat/BuildEnsembleLAM.py
+++ b/src/tasks/oops/bmat/BuildEnsembleLAM.py
@@ -16,7 +16,7 @@ from davai.vtx.hooks.namelists import hook_fix_model, hook_gnam, hook_disable_fu
 
 class BuildEnsemble(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})] + davai.vtx.util.default_experts()
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'historic'})] + davai.vtx.util.default_experts()
 
     def process(self):
         self._wrapped_init()

--- a/src/tasks/oops/model/ModelTLAD.py
+++ b/src/tasks/oops/model/ModelTLAD.py
@@ -99,10 +99,14 @@ class TLAD(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 repo=self.conf.gitenv_repo,
             )
             #-------------------------------------------------------------------------------
+            adiab = {'NAMPHY':{'LMPHYS':False, 'LSOLV':False},
+                     'NAMSIMPHL':{'LSIMPH':False, 'LTRAJPS':False},
+                     }#'NAERAD':{'LRRTM':False, 'LSRTM':False, }}
             # Fix TSTEP,CSTOP in Model objects
             # Disable FullPos use everywhere
             self._wrapped_input(
                 role='OOPSModelObjectsNamelists',
+                hook_adiab=(hook_gnam, adiab if 'adiab' in self.tag else {}),
                 hook_model=(hook_fix_model, '4dvar', False),
                 hook_nofullpos=(hook_disable_fullpos,),
                 intent='inout',

--- a/src/tasks/surfex/pgd.py
+++ b/src/tasks/surfex/pgd.py
@@ -13,7 +13,7 @@ from davai.vtx.tasks.mixins import DavaiIALTaskMixin, IncludesTaskMixin
 
 class PGD(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'pgdfa'}),]
     _taskinfo_kind = 'statictaskinfo'
     _flow_input_task_tag = 'make_domain'
 

--- a/src/tasks/surfex/prep.py
+++ b/src/tasks/surfex/prep.py
@@ -13,7 +13,7 @@ from davai.vtx.hooks.namelists import hook_gnam
 
 class Prep(Task, DavaiIALTaskMixin, IncludesTaskMixin):
 
-    experts = [FPDict({'kind':'fields_in_file'})]
+    experts = [FPDict({'expert':'fields_in_file', 'kind':'initial_condition'}),]
 
     def process(self):
         self._wrapped_init()


### PR DESCRIPTION
* Reorganize MUSC drivers
* Add an adiabatic version of the arpege TLAD test
* Expertise on LFA files : out of MUSC and DDH out of Arpege canonical forecast
* New footprint to fields_in_file experts : `kind` now indicates the kind of files it tackles
* Add Mitra(illette) jobs: FCST and FCTI for global and LAM, in small truncation/domain