### PR TITLE
ddegrauwe alaro1sfx corsica2500

### DIFF
--- a/src/tasks/conf/NRV.yaml
+++ b/src/tasks/conf/NRV.yaml
@@ -2,7 +2,8 @@ forecasts:
     # standalone forecasts = "pure" toy models forecasts without any extra component (DFI, IAU, Fullpos...)
     - standalone_alaro0_antwrp1300
     - standalone_alaro1_antwrp1300
-    - standalone_alaro1sfx_chmh2325
+    #- standalone_alaro1sfx_chmh2325
+    - standalone_alaro1sfx_corsica2500
     - standalone_arome_corsica2500
     - standalone_arpege_globaltst149c24
     - standalone_ifs_global21

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -387,6 +387,16 @@ ntasks              = 32
 nnodes              = 1
 openmp              = 4
 
+[standalone_alaro1sfx_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:30:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
 [standalone_arome_corsica2500]
 rundate             = 2020081800
 pgd_source          = static

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -381,6 +381,16 @@ ntasks              = 32
 nnodes              = 1
 openmp              = 4
 
+[standalone_alaro1sfx_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:30:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
 [standalone_arome_corsica2500]
 rundate             = 2020081800
 pgd_source          = static

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -174,7 +174,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'Atmospheric Initial Conditions',
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',
@@ -209,7 +209,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'BoundaryConditions',  # Initial
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',
@@ -226,7 +226,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'BoundaryConditions',
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',

--- a/src/tasks/forecasts/standalone_alaro1sfx_corsica2500.py
+++ b/src/tasks/forecasts/standalone_alaro1sfx_corsica2500.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .standalone.alaro import StandaloneAlaroForecast
+
+
+def setup(t, **kw):
+    return Driver(tag='drv', ticket=t, options=kw, nodes=[
+        LoopFamily(tag='gmkpack', ticket=t,
+            loopconf='compilation_flavours',
+            loopsuffix='.{}',
+            nodes=[
+                Family(tag='corsica2500', ticket=t, on_error='delayed_fail', nodes=[
+                    Family(tag='alaro1sfx', ticket=t, on_error='delayed_fail', nodes=[
+                        StandaloneAlaroForecast(tag='aplpar', ticket=t, **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
+        ],
+    )
+


### PR DESCRIPTION
Added an ALARO1+SURFEX test running on the (small) corsica2500 domain.
Disabled the test on the (large) CHMH2325 domain.

Necessary files for the new test are on ecmwf:/hpcperm/cv9/davai/alaro1sfx_corsica2500/shelf_cy50.01@davai/
