### PR TITLE
Added coding norms checker expert

### DIFF
--- a/src/davai/cli/experiment.py
+++ b/src/davai/cli/experiment.py
@@ -502,8 +502,10 @@ class XP(object):
                 # fetch sources (interactively)
                 self._gmkpack_fetch_sources(drymode=drymode,
                                             preexisting_pack=preexisting_pack,
-                                            cleanpack=cleanpack)
+                                            cleanpack=cleanpack,
+                                            archive_as_ref=archive_as_ref)
             self._fetch_IAL_config()
+
             # launch build in batch/scheduler
             self._gmkpack_launch_build(drymode=drymode,
                                        cleanpack=cleanpack,
@@ -526,7 +528,8 @@ class XP(object):
     def _gmkpack_fetch_sources(self,
                                drymode=False,
                                preexisting_pack=False,
-                               cleanpack=False):
+                               cleanpack=False,
+                               archive_as_ref=False):
         """Fetch sources for build with gmkpack."""
         if 'IAL_git_ref' in self.sources_to_test:
             # build from a single IAL Git reference
@@ -542,6 +545,7 @@ class XP(object):
                      profile='rd',  # interactive, not in batch/scheduler
                      preexisting_pack=preexisting_pack,
                      cleanpack=cleanpack,
+                     archive_as_ref=archive_as_ref,
                      **self.sources_to_test)
 
     def _gmkpack_launch_build(self,

--- a/src/davai/vtx/algo/build.py
+++ b/src/davai/vtx/algo/build.py
@@ -184,12 +184,18 @@ class IALgitref2Pack(AlgoComponent, GmkpackDecoMixin, GitDecoMixin):
                     optional = True,
                     default = None,
                 ),
+                check_coding_norms = dict(
+                    info = "Run coding norms checker on local sources",
+                    optional = True,
+                    default = False,
+                )
             )
         )
     ]
 
     def execute(self, rh, kw):  # @UnusedVariable
         from ial_build.algos import IALgitref2pack  # @UnresolvedImport
+
         IALgitref2pack(self.git_ref,
                        self.repository,
                        pack_type=self.pack_type,
@@ -198,7 +204,8 @@ class IALgitref2Pack(AlgoComponent, GmkpackDecoMixin, GitDecoMixin):
                        compiler_label=self.compiler_label,
                        compiler_flag=self.compiler_flag,
                        homepack=self.homepack,
-                       rootpack=self.rootpack)
+                       rootpack=self.rootpack,
+                       check_coding_norms=self.check_coding_norms)
 
 
 class IALgitref2Pack_CrashWitness(IALgitref2Pack, _CrashWitnessDecoMixin):

--- a/src/tasks/build/gmkpack/gitref2pack.py
+++ b/src/tasks/build/gmkpack/gitref2pack.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, absolute_import, unicode_literals, division
 
+from footprints import FPDict
 import vortex
 from vortex import toolbox
 from vortex.layout.nodes import Task, Driver, Family, LoopFamily
@@ -25,13 +26,16 @@ def setup(t, **kw):
 
 class GitRef2Pack(Task, DavaiTaskMixin, GmkpackMixin):
 
+    experts = [FPDict({'kind':'codingnorms'}),]
+    _taskinfo_kind = 'statictaskinfo'
+
     def process(self):
         self._set_gmkpack_env()
         self._wrapped_init()
 
         # 0./ Promises
         if 'early-fetch' in self.steps or 'fetch' in self.steps:
-            pass
+            self._wrapped_promise(**self._promised_expertise())
             #-------------------------------------------------------------------------------
 
         # 1.1.0/ Reference resources, to be compared to:
@@ -79,12 +83,14 @@ class GitRef2Pack(Task, DavaiTaskMixin, GmkpackMixin):
                 pack_type      = self.conf.packtype,
                 preexisting_pack = self.conf.preexisting_pack,
                 repository     = self.conf.IAL_repository,
-                rootpack       = self.conf.get('rootpack', None)
+                rootpack       = self.conf.get('rootpack', None),
+                check_coding_norms = self.conf.get('check_coding_norms',False),
             )
             print(self.ticket.prompt, 'tbalgo =', tbalgo)
             print()
             self.component_runner(tbalgo, [None])
             #-------------------------------------------------------------------------------
+            self.run_expertise()
             #-------------------------------------------------------------------------------
 
         # 2.3/ Flow Resources: produced by this task and possibly used by a subsequent flow-dependant task
@@ -94,7 +100,7 @@ class GitRef2Pack(Task, DavaiTaskMixin, GmkpackMixin):
 
         # 3.0.1/ Davai expertise:
         if 'late-backup' in self.steps or 'backup' in self.steps:
-            pass
+            self._wrapped_output(**self._output_expertise())
             #-------------------------------------------------------------------------------
 
         # 3.0.2/ Other output resources of possible interest:

--- a/src/tasks/conf/NRV.yaml
+++ b/src/tasks/conf/NRV.yaml
@@ -2,7 +2,8 @@ forecasts:
     # standalone forecasts = "pure" toy models forecasts without any extra component (DFI, IAU, Fullpos...)
     - standalone_alaro0_antwrp1300
     - standalone_alaro1_antwrp1300
-    - standalone_alaro1sfx_chmh2325
+    #- standalone_alaro1sfx_chmh2325
+    - standalone_alaro1sfx_corsica2500
     - standalone_arome_corsica2500
     - standalone_arpege_globaltst149c24
     - standalone_ifs_global21

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -387,6 +387,16 @@ ntasks              = 32
 nnodes              = 1
 openmp              = 4
 
+[standalone_alaro1sfx_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:30:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
 [standalone_arome_corsica2500]
 rundate             = 2020081800
 pgd_source          = static

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -247,6 +247,9 @@ suite_vconf         = armcu
 
 # ======================================================================= TASKS
 
+[gitref2pack]
+check_coding_norms = True
+
 [pack2bin]
 threads             = ${ntasks}
 Ofrt                = 4

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -381,6 +381,16 @@ ntasks              = 32
 nnodes              = 1
 openmp              = 4
 
+[standalone_alaro1sfx_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:30:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
 [standalone_arome_corsica2500]
 rundate             = 2020081800
 pgd_source          = static

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -174,7 +174,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'Atmospheric Initial Conditions',
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',
@@ -209,7 +209,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'BoundaryConditions',  # Initial
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',
@@ -226,7 +226,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
             self._wrapped_input(
                 role           = 'BoundaryConditions',
-                block          = 'coupling',
+                block          = 'coupling_alaro',
                 date           = self.conf.rundate,
                 experiment     = self.conf.input_shelf,
                 format         = '[nativefmt]',

--- a/src/tasks/forecasts/standalone_alaro1sfx_corsica2500.py
+++ b/src/tasks/forecasts/standalone_alaro1sfx_corsica2500.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .standalone.alaro import StandaloneAlaroForecast
+
+
+def setup(t, **kw):
+    return Driver(tag='drv', ticket=t, options=kw, nodes=[
+        LoopFamily(tag='gmkpack', ticket=t,
+            loopconf='compilation_flavours',
+            loopsuffix='.{}',
+            nodes=[
+                Family(tag='corsica2500', ticket=t, on_error='delayed_fail', nodes=[
+                    Family(tag='alaro1sfx', ticket=t, on_error='delayed_fail', nodes=[
+                        StandaloneAlaroForecast(tag='aplpar', ticket=t, **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
+        ],
+    )
+


### PR DESCRIPTION
Activated by setting

```
[gitref2pack]
check_coding_norms = True
```

in davai_nrv.ini

Requires branches modifications to ial_build and ial_expertise:
https://github.com/ACCORD-NWP/IAL-build/pull/9
https://github.com/ACCORD-NWP/IAL-expertise/pull/7
