### PR TITLE
Cy50t1 ha deode davai testing

### DIFF
--- a/src/tasks/conf/NRV.yaml
+++ b/src/tasks/conf/NRV.yaml
@@ -4,6 +4,7 @@ forecasts:
     - standalone_alaro1_antwrp1300
     - standalone_alaro1sfx_chmh2325
     - standalone_arome_corsica2500
+    - standalone_harmoniearome_nl2500
     - standalone_arpege_globaltst149c24
     - standalone_ifs_global21
     # canonical forecasts = close to operations, including extra components

--- a/src/tasks/conf/NRV.yaml
+++ b/src/tasks/conf/NRV.yaml
@@ -4,7 +4,8 @@ forecasts:
     - standalone_alaro1_antwrp1300
     - standalone_alaro1sfx_chmh2325
     - standalone_arome_corsica2500
-    - standalone_harmoniearome_nl2500
+    - standalone_harmoniearome_deode_nl1000
+      #    - standalone_harmoniearome_nl2500
     - standalone_arpege_globaltst149c24
     - standalone_ifs_global21
     # canonical forecasts = close to operations, including extra components

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -12,17 +12,17 @@ billing_account     = spfracco
 billing_account_ft  = spfracco
 uenv_gdata_detour   = davai_gmirror
 # static resources : uenv/genv
-davaienv            = uenv:cy50t1.davai_specials.06@davai
+davaienv            = uenv:cy50t1.davai_specials.06@nlcr
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.05@davai
-appenv_lam          = uenv:cy50t1.LAM@davai.08@davai
+appenv_lam          = uenv:cy50t1.LAM@davai.08@nlcr
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.02@davai
 appenv_clim         = uenv:cy50t1_clim.03@davai
 commonenv           = ${appenv_global}
 # static resources: gitenv
 ial_config_repo     = $HOME/davai/IAL-config
-ial_config_ref      = davai50t1.01
+ial_config_ref      = davai50t1.02
 # pseudo-dataflow resources : shelves
-input_shelf         = shelf_cy50.01@davai
+input_shelf         = shelf_cy50.02@davai
 shelves_vapp        = davai
 shelves_vconf       = shelves
 shelves2bucket      = False
@@ -71,7 +71,7 @@ compilation_flavours = list(OMPIIFC2302DP2.y,OMPIIFC2302SP2.y)
 # GMKPACK install: do not rely on user's
 GMKROOT = /home/rme/public/bin/gmkpack
 GMK_SUPPORT = /home/rme/public/bin/gmkpack_support
-HOMEPACK = $PERM/pack
+HOMEPACK = $SCRATCH/pack
 # FIXME: issue if this is not specified
 GMKFILE = OMPIIFC2302DP.AA
 
@@ -132,6 +132,15 @@ fcst_term           = 12
 expertise_term      = 12
 coupling_frequency  = 3
 alaro_version       = 1_sfx
+
+[harmoniearome]
+model               = harmoniearome
+suite_vapp          = &{model}
+LAM                 = True
+appenv              = &{appenv_lam}
+fcst_term           = 12
+expertise_term      = 12
+coupling_frequency  = 1
 
 [4dvar6h]
 timeslots           = 7
@@ -219,6 +228,10 @@ timestep            = 600
 
 [corsica2500]
 geometry            = geometry(corsica2500)
+timestep            = 60
+
+[nl2500]
+geometry            = geometry(nl2500)
 timestep            = 60
 
 [global21]
@@ -339,7 +352,7 @@ time                = 03:00:00
 ntasks              = 64
 mem                 = 40000
 loadedjaplugins     = davaidev,git
-bundle_src_dir      = $PERM/bundle_cache
+bundle_src_dir      = $SCRATCH/bundle_cache
 
 # FORECASTS
 # =========
@@ -388,6 +401,16 @@ nnodes              = 1
 openmp              = 4
 
 [standalone_arome_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:00:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[standalone_harmoniearome_nl2500]
 rundate             = 2020081800
 pgd_source          = static
 surf_ic_source      = static

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -12,9 +12,9 @@ billing_account     = spfracco
 billing_account_ft  = spfracco
 uenv_gdata_detour   = davai_gmirror
 # static resources : uenv/genv
-davaienv            = uenv:cy50t1.davai_specials.06@nlcr
+davaienv            = uenv:cy50t1.davai_specials.07@davai
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.05@davai
-appenv_lam          = uenv:cy50t1.LAM@davai.08@nlcr
+appenv_lam          = uenv:cy50t1.LAM@davai.09@davai
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.02@davai
 appenv_clim         = uenv:cy50t1_clim.03@davai
 commonenv           = ${appenv_global}

--- a/src/tasks/conf/atos_bologna.ini
+++ b/src/tasks/conf/atos_bologna.ini
@@ -12,7 +12,7 @@ billing_account     = spfracco
 billing_account_ft  = spfracco
 uenv_gdata_detour   = davai_gmirror
 # static resources : uenv/genv
-davaienv            = uenv:cy50t1.davai_specials.07@davai
+davaienv            = uenv:cy50t1.davai_specials.06@davai
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.05@davai
 appenv_lam          = uenv:cy50t1.LAM@davai.09@davai
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.02@davai
@@ -20,9 +20,9 @@ appenv_clim         = uenv:cy50t1_clim.03@davai
 commonenv           = ${appenv_global}
 # static resources: gitenv
 ial_config_repo     = $HOME/davai/IAL-config
-ial_config_ref      = davai50t1.02
+ial_config_ref      = bef9904784f2edcdb1dbdb3fcdf5abd0d65059a6
 # pseudo-dataflow resources : shelves
-input_shelf         = shelf_cy50.02@davai
+input_shelf         = shelf_cy50.01@davai
 shelves_vapp        = davai
 shelves_vconf       = shelves
 shelves2bucket      = False
@@ -32,7 +32,7 @@ ciboulai_token_file = /home/acrd/public/ciboulai/token.2022-10-20
 ciboulai_send_tries = 2
 expertise_fatal_exceptions = False
 drhook_profiling    = True
-ignore_reference    = False
+ignore_reference    = True
 hide_equal_norms    = True
 hook_davai_wagons   = __all__
 ref_namespace       = vortex.multi.fr
@@ -138,8 +138,8 @@ model               = harmoniearome
 suite_vapp          = &{model}
 LAM                 = True
 appenv              = &{appenv_lam}
-fcst_term           = 12
-expertise_term      = 12
+fcst_term           = 6
+expertise_term      = 6
 coupling_frequency  = 1
 
 [4dvar6h]
@@ -229,6 +229,10 @@ timestep            = 600
 [corsica2500]
 geometry            = geometry(corsica2500)
 timestep            = 60
+
+[nl1000]
+geometry            = geometry(nl1000)
+timestep            = 30
 
 [nl2500]
 geometry            = geometry(nl2500)
@@ -402,6 +406,16 @@ openmp              = 4
 
 [standalone_arome_corsica2500]
 rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:00:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[standalone_harmoniearome_deode_nl1000]
+rundate             = 2025041200
 pgd_source          = static
 surf_ic_source      = static
 # profile (ntasks = ntasks/node)

--- a/src/tasks/conf/belenos.ini
+++ b/src/tasks/conf/belenos.ini
@@ -6,17 +6,17 @@ profile_mkjob       = rd-belenos-mt
 ref_xpid            = dv-0504-belenos@mary
 ref_vconf           = elp
 # static resources : uenv/genv
-davaienv            = uenv:cy50t1.davai_specials.06@davai
+davaienv            = uenv:cy50t1.davai_specials.07@davai
 appenv_global       = uenv:cy50t1.arpege@4dvarfr.05@davai
-appenv_lam          = uenv:cy50t1.LAM@davai.08@davai
+appenv_lam          = uenv:cy50t1.LAM@davai.09@davai
 appenv_fullpos_partners = uenv:cy50t1.fullpos@partners.02@davai
 appenv_clim         = uenv:cy50t1_clim.03@davai
 commonenv           = ${appenv_global}
 # static resources: gitenv
 ial_config_repo     = $HOME/davai/IAL-config
-ial_config_ref      = davai50t1.01
+ial_config_ref      = davai50t1.02
 # pseudo-dataflow resources : shelves
-input_shelf         = shelf_cy50.01@davai
+input_shelf         = shelf_cy50.02@davai
 shelves_vapp        = davai
 shelves_vconf       = shelves
 shelves2bucket      = False
@@ -127,6 +127,15 @@ expertise_term      = 12
 coupling_frequency  = 3
 alaro_version       = 1_sfx
 
+[harmoniearome]
+model               = harmoniearome
+suite_vapp          = &{model}
+LAM                 = True
+appenv              = &{appenv_lam}
+fcst_term           = 12
+expertise_term      = 12
+coupling_frequency  = 1
+
 [4dvar6h]
 timeslots           = 7
 window_start        = -PT3H
@@ -213,6 +222,10 @@ timestep            = 600
 
 [corsica2500]
 geometry            = geometry(corsica2500)
+timestep            = 60
+
+[nl2500]
+geometry            = geometry(nl2500)
 timestep            = 60
 
 [global21]
@@ -382,6 +395,16 @@ nnodes              = 1
 openmp              = 4
 
 [standalone_arome_corsica2500]
+rundate             = 2020081800
+pgd_source          = static
+surf_ic_source      = static
+# profile (ntasks = ntasks/node)
+time                = 01:00:00
+ntasks              = 32
+nnodes              = 1
+openmp              = 4
+
+[standalone_harmoniearome_nl2500]
 rundate             = 2020081800
 pgd_source          = static
 surf_ic_source      = static

--- a/src/tasks/forecasts/standalone_harmoniearome_deode_nl1000.py
+++ b/src/tasks/forecasts/standalone_harmoniearome_deode_nl1000.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .standalone.arome import StandaloneAromeForecast
+
+
+def setup(t, **kw):
+    return Driver(tag='drv', ticket=t, options=kw, nodes=[
+        LoopFamily(tag='gmkpack', ticket=t,
+            loopconf='compilation_flavours',
+            loopsuffix='.{}',
+            nodes=[
+                Family(tag='harmoniearome', ticket=t, on_error='delayed_fail', nodes=[
+                    Family(tag='nl1000', ticket=t, nodes=[
+                        StandaloneAromeForecast(tag='arome_nominal', on_error='delayed_fail', ticket=t, **kw),
+                        StandaloneAromeForecast(tag='arome_nproma32', ticket=t, **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
+        ],
+    )
+

--- a/src/tasks/forecasts/standalone_harmoniearome_nl2500.py
+++ b/src/tasks/forecasts/standalone_harmoniearome_nl2500.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from vortex.layout.nodes import Family, Driver, LoopFamily
+
+from .standalone.arome import StandaloneAromeForecast
+
+
+def setup(t, **kw):
+    return Driver(tag='drv', ticket=t, options=kw, nodes=[
+        LoopFamily(tag='gmkpack', ticket=t,
+            loopconf='compilation_flavours',
+            loopsuffix='.{}',
+            nodes=[
+                Family(tag='harmoniearome', ticket=t, on_error='delayed_fail', nodes=[
+                    Family(tag='nl2500', ticket=t, nodes=[
+                        StandaloneAromeForecast(tag='arome_nominal', on_error='delayed_fail', ticket=t, **kw),
+                        StandaloneAromeForecast(tag='arome_nproma32', ticket=t, **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
+        ],
+    )
+


### PR DESCRIPTION
This PR is for Harmonie Arome in DEODE for DAVAI testing.

-  Built IAL CY50T1_deode binaries from Miguel's compile instructions. (https://github.com/destination-earth-digital-twins/IAL/tree/CY50T1_deode)

- Built gl binary for CY50T1 as well.

- Simulated on a test domain (80x90) grid points for 1 km resolution over the Netherlands domain for 6 hours.

-  Used the surface and upper air namelists in the DAVAI experiment (https://www.umr-cnrm.fr/davai/lightView/2574)

-  Created a standalone forecast test for Harmonie-Arome-DEODE and used the built binaries DP and SP for the DAVAI testing on ATOS (/ec/res4/scratch/sbyk/pack)